### PR TITLE
Add author and title into meta tags of the generated document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 *.ez
 
 /uploads
+/organisations
 /temp
 /priv/static/swagger.json
 

--- a/priv/repo/data/minio/update_slugs.exs
+++ b/priv/repo/data/minio/update_slugs.exs
@@ -1,0 +1,22 @@
+defmodule WraftDoc.Minio.UpdateSlugs do
+  @moduledoc """
+   Update changes in the slug files
+
+    Script for updating the slug files. You can run it as:
+
+     mix run priv/repo/data/minio/update_slugs.exs
+  """
+
+  require Logger
+  alias WraftDoc.Minio.Utils
+
+  wraft_bucket = System.get_env("MINIO_BUCKET")
+
+  Logger.info("Update slugs in object storage")
+
+  # Move slugs
+  slugs_file_path = Path.join(File.cwd!(), "priv/slugs")
+  Utils.upload_files(wraft_bucket, slugs_file_path, "public/slugs")
+
+  Logger.info("Update slugs in object storage completed")
+end

--- a/priv/slugs/contract/template.tex
+++ b/priv/slugs/contract/template.tex
@@ -51,22 +51,22 @@
 \sectionfont{\color{foo}}
 
 $if(mainfont)$
-  \setmainfont[
-    Path=$path$/fonts/,
-    $for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$
+\setmainfont[
+  Path=$path$/fonts/,
+  $for(mainfontoptions)$$mainfontoptions$$sep$,$endfor$
   ]{$mainfont$}
-$endif$
+  $endif$
 
-% Longtabe and friends
-\usepackage{rotating,multirow,longtable,booktabs}
+  % Longtabe and friends
+  \usepackage{rotating,multirow,longtable,booktabs}
 
-% Polyglossia settings
-\setmainlanguage{english} % or danish
-\addto\captionsenglish{%
+  % Polyglossia settings
+  \setmainlanguage{english} % or danish
+  \addto\captionsenglish{%
   \renewcommand{\contentsname}{Table of Contents}
-}
+  }
 \addto\captionsdanish{%
-  \renewcommand{\contentsname}{Indholdsfortegnelse}
+\renewcommand{\contentsname}{Indholdsfortegnelse}
 }
 
 \renewcommand{\baselinestretch}{1.25}
@@ -85,6 +85,15 @@ $highlighting-macros$
 
 \newcommand{\authorName}{$author_name$}
 \newcommand{\authorEmail}{$author_email$}
+
+% Set the PDF metadata
+\usepackage{hyperref}
+\newcommand{\DocumentInstanceTitle}{$title$}
+\newcommand{\pdfAuthor}{$organisation_name$}
+\hypersetup{
+  pdftitle={\DocumentInstanceTitle},
+  pdfauthor={\pdfAuthor}
+}
 
 % Don't let images overflow the page
 % Can still explicit set width/height/options for an image

--- a/priv/slugs/pletter/template.tex
+++ b/priv/slugs/pletter/template.tex
@@ -192,6 +192,15 @@ $else$
 \fi
 $endif$
 
+% Set the PDF metadata
+\usepackage{hyperref}
+\newcommand{\DocumentInstanceTitle}{$title$}
+\newcommand{\pdfAuthor}{$organisation_name$}
+\hypersetup{
+  pdftitle={\DocumentInstanceTitle},
+  pdfauthor={\pdfAuthor}
+}
+
 % set default figure placement to htbp
 \makeatletter
 \def\fps@figure{htbp}


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [x] Feature addition
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please specify)

## Description

This pull request adds meta tags for author and title into the generated document. 

## Related Issue

Fixes #(issue number)

## Motivation and Context

Generated document was not showing any information about title or author. After this fix, they would be shown.
## How Has This Been Tested?

This was tested by generating the document and checking the document properties after opening the generated document in a browser or any other pdf viewer. It would be possible to see the title and author in the generated document.

![image](https://github.com/user-attachments/assets/0fbeec03-1dc4-4d5e-8196-6e16882d3958)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.

## Additional Notes

Add any other context about the pull request here.
