### PR TITLE
File name correction in generated document pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 *.ez
 
 /uploads
+/organisations
 /temp
 /users
 /organisations

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 *.ez
 
 /uploads
-/organisations
 /temp
 /users
 /organisations

--- a/lib/wraft_doc/document/document.ex
+++ b/lib/wraft_doc/document/document.ex
@@ -1850,16 +1850,11 @@ defmodule WraftDoc.Document do
     |> then(&Path.join(instance_dir_path, &1))
   end
 
-  defp versioned_file_name([], _instance_id, :current), do: nil
-  defp versioned_file_name([_ | []], instance_id, :current), do: instance_id <> ".pdf"
-
   defp versioned_file_name(versions, instance_id, :current),
-    do: instance_id <> "-v" <> to_string(length(versions) - 1) <> ".pdf"
-
-  defp versioned_file_name([], instance_id, :next), do: instance_id <> ".pdf"
+    do: instance_id <> "-v" <> to_string(length(versions)) <> ".pdf"
 
   defp versioned_file_name(versions, instance_id, :next),
-    do: instance_id <> "-v" <> to_string(length(versions)) <> ".pdf"
+    do: instance_id <> "-v" <> to_string(length(versions) + 1) <> ".pdf"
 
   defp prepare_markdown(
          %{id: instance_id, creator: %User{name: name, email: email}} = instance,

--- a/lib/wraft_doc/logic_pipeline/pipeline_runner.ex
+++ b/lib/wraft_doc/logic_pipeline/pipeline_runner.ex
@@ -180,7 +180,7 @@ defmodule WraftDoc.PipelineRunner do
 
     builds =
       instances
-      |> Stream.map(fn x -> x |> Document.get_built_document(local: true) |> Map.get(:build) end)
+      |> Stream.map(fn x -> x |> Document.get_built_document() |> Map.get(:build) end)
       |> Stream.filter(fn x -> x != nil end)
       |> Enum.map(&String.to_charlist/1)
 

--- a/lib/wraft_doc_web/controllers/instance_approval_system_controller.ex
+++ b/lib/wraft_doc_web/controllers/instance_approval_system_controller.ex
@@ -33,7 +33,7 @@ defmodule WraftDocWeb.Api.V1.InstanceApprovalSystemController do
             instance_id: "OFFL01",
             raw: "Content",
             serialized: %{title: "Title of the content", body: "Body of the content"},
-            build: "/organisations/f5837766-573f-427f-a916-cf39a3518c7b/OFFL01/final.pdf",
+            build: "/organisations/f5837766-573f-427f-a916-cf39a3518c7b/OFFL01/OFFLET-v1.pdf",
             updated_at: "2020-01-21T14:00:00Z",
             inserted_at: "2020-02-21T14:00:00Z"
           })
@@ -116,7 +116,7 @@ defmodule WraftDocWeb.Api.V1.InstanceApprovalSystemController do
               instance_id: "OFFL01",
               raw: "Content",
               serialized: %{title: "Title of the content", body: "Body of the content"},
-              build: "/organisations/f5837766-573f-427f-a916-cf39a3518c7b/OFFL01/final.pdf",
+              build: "/organisations/f5837766-573f-427f-a916-cf39a3518c7b/OFFL01/OFFLET-v1.pdf",
               updated_at: "2020-01-21T14:00:00Z",
               inserted_at: "2020-02-21T14:00:00Z"
             },
@@ -160,7 +160,8 @@ defmodule WraftDocWeb.Api.V1.InstanceApprovalSystemController do
                   instance_id: "OFFL01",
                   raw: "Content",
                   serialized: %{title: "Title of the content", body: "Body of the content"},
-                  build: "/organisations/f5837766-573f-427f-a916-cf39a3518c7b/OFFL01/final.pdf",
+                  build:
+                    "/organisations/f5837766-573f-427f-a916-cf39a3518c7b/OFFL01/OFFLET-v1.pdf",
                   updated_at: "2020-01-21T14:00:00Z",
                   inserted_at: "2020-02-21T14:00:00Z"
                 },

--- a/lib/wraft_doc_web/controllers/instance_controller.ex
+++ b/lib/wraft_doc_web/controllers/instance_controller.ex
@@ -54,7 +54,7 @@ defmodule WraftDocWeb.Api.V1.InstanceController do
             instance_id: "OFFL01",
             raw: "Content",
             serialized: %{title: "Title of the content", body: "Body of the content"},
-            build: "/uploads/OFFL01/final.pdf",
+            build: "/uploads/OFFL01/OFFL01-v1.pdf",
             updated_at: "2020-01-21T14:00:00Z",
             inserted_at: "2020-02-21T14:00:00Z"
           })

--- a/lib/wraft_doc_web/controllers/template_asset_controller.ex
+++ b/lib/wraft_doc_web/controllers/template_asset_controller.ex
@@ -15,8 +15,8 @@ defmodule WraftDocWeb.Api.V1.TemplateAssetController do
 
   action_fallback(WraftDocWeb.FallbackController)
 
-  alias WraftDoc.Document.DataTemplate
   alias WraftDoc.Document
+  alias WraftDoc.Document.DataTemplate
   alias WraftDoc.TemplateAssets
   alias WraftDoc.TemplateAssets.TemplateAsset
 

--- a/lib/wraft_doc_web/email/email.ex
+++ b/lib/wraft_doc_web/email/email.ex
@@ -128,26 +128,33 @@ defmodule WraftDocWeb.Mailer.Email do
   @doc """
     Document Instance Mail
   """
-  def document_instance_mail(email, subject, message, cc_list, document_pdf_binary) do
+  def document_instance_mail(
+        email,
+        subject,
+        message,
+        cc_list,
+        document_pdf_binary,
+        instance_file_name
+      ) do
     new()
     |> to(email)
     |> maybe_add_cc(cc_list)
     |> from({"Wraft", sender_email()})
     |> subject(subject)
     |> html_body(message)
-    |> add_attachment(document_pdf_binary)
+    |> add_attachment(document_pdf_binary, instance_file_name)
   end
 
   defp maybe_add_cc(email, nil), do: email
 
   defp maybe_add_cc(email, cc_list), do: cc(email, cc_list)
 
-  defp add_attachment(email, document_pdf_binary) do
+  defp add_attachment(email, document_pdf_binary, instance_file_name) do
     attachment(
       email,
       Attachment.new(
         {:data, document_pdf_binary},
-        filename: "final.pdf",
+        filename: instance_file_name,
         content_type: "application/pdf",
         type: :inline
       )

--- a/priv/repo/data/content.json
+++ b/priv/repo/data/content.json
@@ -48,6 +48,6 @@
     "instance_id": "rl0019",
     "inserted_at": "2022-02-02T04:10:30",
     "id": "cdd587d1-4784-4c3c-ab84-1fac7f47b6b6",
-    "build": "organisations/f5837766-573f-427f-a916-cf39a3518c7b/contents/rl0019/final.pdf"
+    "build": "organisations/f5837766-573f-427f-a916-cf39a3518c7b/contents/rl0019/OFFLET-v1.pdf"
   }
 }

--- a/priv/repo/data/rbac/permissions.csv
+++ b/priv/repo/data/rbac/permissions.csv
@@ -94,4 +94,5 @@ form_mapping:show,Form Mapping,Show
 template_asset:manage,TemplateAsset,Manage
 template_asset:delete,TemplateAsset,Delete
 template_asset:template_import,TemplateAsset,Manage
+template_asset:template_export,TemplateAsset,Manage
 dashboard:show,DashBoard,Show


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [x] Feature addition
- [ ] Bug fix
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please specify)

## Description

* Add file name of the generated document as `OFFLET-v1.pdf` instead of final.pdf. 
* Files are distinctively added with a version suffix

## Motivation and Context

Why is this change required? What problem does it solve?

* To ensure that versions can be read from the filename itself.

## How Has This Been Tested?

* Attempt to generate the document from UI and download the file and observe the filename.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.