### PR TITLE
feat: add importing frames and renamed slugs to frames

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,26 @@
+name: "lint-pr-title"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install commitlint
+        run: npm install -g @commitlint/config-conventional@19 @commitlint/cli@19
+
+      - name: Configure commitlint
+        run: |
+          echo "export default { extends: ['@commitlint/config-conventional'] };" > commitlint.config.mjs
+
+      - name: Check PR Title
+        run: |
+          echo The Title of your PR is "$PR_TITLE"
+          echo "$PR_TITLE" | commitlint --verbose
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.gitignore
+++ b/.gitignore
@@ -60,4 +60,9 @@ npm-debug.log
 /lib/slugs/**/template.fdb_latexmk
 /lib/slugs/**/template.fls
 /lib/slugs/**/template.log
+# Ignore the slug files except few slugs.
+priv/slugs/*
+!priv/slugs/contract/**
+!priv/slugs/gantt_chart/**
+!priv/slugs/pletter/**
 .env.custom

--- a/lib/wraft_doc/document/frame.ex
+++ b/lib/wraft_doc/document/frame.ex
@@ -3,8 +3,6 @@ defmodule WraftDoc.Document.Frame do
   use Waffle.Ecto.Schema
   use WraftDoc.Schema
 
-  @reserved_names ["contract", "pletter", "gantt_chart"]
-
   schema "frame" do
     field(:name, :string)
     field(:frame_file, WraftDocWeb.FrameUploader.Type)
@@ -36,9 +34,6 @@ defmodule WraftDoc.Document.Frame do
     |> cast(attrs, [:name, :organisation_id, :creator_id])
     |> cast_attachments(attrs, [:frame_file])
     |> validate_required([:name, :frame_file])
-    |> validate_exclusion(:name, @reserved_names,
-      message: "is a reserved name and cannot be used"
-    )
     |> unique_constraint(:name,
       name: :frame_name_organisation_id_index,
       message: "Frame with the same name  under your organisation exists.!"

--- a/lib/wraft_doc/document/frame.ex
+++ b/lib/wraft_doc/document/frame.ex
@@ -19,9 +19,6 @@ defmodule WraftDoc.Document.Frame do
     frame
     |> cast(attrs, [:name, :organisation_id, :creator_id])
     |> validate_required([:name, :organisation_id, :creator_id])
-    |> validate_exclusion(:name, @reserved_names,
-      message: "is a reserved name and cannot be used"
-    )
     |> unique_constraint(:name,
       name: :frame_name_organisation_id_index,
       message: "Frame with the same name  under your organisation exists.!"

--- a/lib/wraft_doc/document/frame.ex
+++ b/lib/wraft_doc/document/frame.ex
@@ -3,6 +3,8 @@ defmodule WraftDoc.Document.Frame do
   use Waffle.Ecto.Schema
   use WraftDoc.Schema
 
+  @reserved_names ["contract", "pletter", "gantt_chart"]
+
   schema "frame" do
     field(:name, :string)
     field(:frame_file, WraftDocWeb.FrameUploader.Type)
@@ -17,6 +19,13 @@ defmodule WraftDoc.Document.Frame do
     frame
     |> cast(attrs, [:name, :organisation_id, :creator_id])
     |> validate_required([:name, :organisation_id, :creator_id])
+    |> validate_exclusion(:name, @reserved_names,
+      message: "is a reserved name and cannot be used"
+    )
+    |> unique_constraint(:name,
+      name: :frame_name_organisation_id_index,
+      message: "Frame with the same name  under your organisation exists.!"
+    )
   end
 
   def file_changeset(frame, attrs) do
@@ -30,5 +39,12 @@ defmodule WraftDoc.Document.Frame do
     |> cast(attrs, [:name, :organisation_id, :creator_id])
     |> cast_attachments(attrs, [:frame_file])
     |> validate_required([:name, :frame_file])
+    |> validate_exclusion(:name, @reserved_names,
+      message: "is a reserved name and cannot be used"
+    )
+    |> unique_constraint(:name,
+      name: :frame_name_organisation_id_index,
+      message: "Frame with the same name  under your organisation exists.!"
+    )
   end
 end

--- a/lib/wraft_doc/document/frame.ex
+++ b/lib/wraft_doc/document/frame.ex
@@ -1,0 +1,34 @@
+defmodule WraftDoc.Document.Frame do
+  @moduledoc false
+  use Waffle.Ecto.Schema
+  use WraftDoc.Schema
+
+  schema "frame" do
+    field(:name, :string)
+    field(:frame_file, WraftDocWeb.FrameUploader.Type)
+
+    belongs_to(:creator, WraftDoc.Account.User)
+    belongs_to(:organisation, WraftDoc.Enterprise.Organisation)
+
+    timestamps()
+  end
+
+  def changeset(frame, attrs) do
+    frame
+    |> cast(attrs, [:name, :organisation_id, :creator_id])
+    |> validate_required([:name, :organisation_id, :creator_id])
+  end
+
+  def file_changeset(frame, attrs) do
+    frame
+    |> cast_attachments(attrs, [:frame_file])
+    |> validate_required([:frame_file])
+  end
+
+  def update_changeset(frame, attrs) do
+    frame
+    |> cast(attrs, [:name, :organisation_id, :creator_id])
+    |> cast_attachments(attrs, [:frame_file])
+    |> validate_required([:name, :frame_file])
+  end
+end

--- a/lib/wraft_doc/document/frames.ex
+++ b/lib/wraft_doc/document/frames.ex
@@ -13,7 +13,7 @@ defmodule WraftDoc.Document.Frames do
   @doc """
   Lists all frames.
   """
-  @spec list_frames(User.t(), map) :: map
+  @spec list_frames(User.t(), map()) :: map()
   def list_frames(%{current_org_id: organisation_id}, params) do
     query =
       from(s in Frame,
@@ -27,7 +27,7 @@ defmodule WraftDoc.Document.Frames do
   def list_frames(_, _), do: {:error, :fake}
 
   @doc """
-  Gets a specific frame.
+  Retrieves a specific frame.
   """
   @spec get_frame(binary(), User.t()) :: Frame.t() | nil
   def get_frame(<<_::288>> = id, %{current_org_id: organisation_id}) do
@@ -76,13 +76,13 @@ defmodule WraftDoc.Document.Frames do
   Delete a frame.
   """
   @spec delete_frame(Frame.t()) :: {:ok, Frame.t()} | {:error, Ecto.Changeset.t()}
-  def delete_frame(%Frame{} = frame) do
-    case Minio.delete_file("organisations/#{frame.organisation_id}/frames/#{frame.id}") do
+  def delete_frame(%Frame{id: frame_id, organisation_id: organisation_id, name: name} = frame) do
+    case Minio.delete_file("organisations/#{organisation_id}/frames/#{frame_id}") do
       {:ok, _} ->
         frame_path =
           :wraft_doc
           |> :code.priv_dir()
-          |> Path.join("slugs/#{frame.name}")
+          |> Path.join("slugs/#{name}")
 
         if File.exists?(frame_path) do
           File.rm_rf(frame_path)

--- a/lib/wraft_doc/document/frames.ex
+++ b/lib/wraft_doc/document/frames.ex
@@ -79,6 +79,15 @@ defmodule WraftDoc.Document.Frames do
   def delete_frame(%Frame{} = frame) do
     case Minio.delete_file("organisations/#{frame.organisation_id}/frames/#{frame.id}") do
       {:ok, _} ->
+        frame_path =
+          :wraft_doc
+          |> :code.priv_dir()
+          |> Path.join("slugs/#{frame.name}")
+
+        if File.exists?(frame_path) do
+          File.rm_rf(frame_path)
+        end
+
         Repo.delete(frame)
 
       {:error, reason} ->

--- a/lib/wraft_doc/document/frames.ex
+++ b/lib/wraft_doc/document/frames.ex
@@ -1,0 +1,88 @@
+defmodule WraftDoc.Document.Frames do
+  @moduledoc """
+  Module that handles frame related contexts.
+  """
+  import Ecto.Query
+  require Logger
+
+  alias Ecto.Multi
+  alias WraftDoc.Client.Minio
+  alias WraftDoc.Document.Frame
+  alias WraftDoc.Repo
+
+  @doc """
+  Lists all frames.
+  """
+  @spec list_frames(User.t(), map) :: map
+  def list_frames(%{current_org_id: organisation_id}, params) do
+    query =
+      from(s in Frame,
+        where: s.organisation_id == ^organisation_id,
+        order_by: [desc: s.inserted_at]
+      )
+
+    Repo.paginate(query, params)
+  end
+
+  def list_frames(_, _), do: {:error, :fake}
+
+  @doc """
+  Gets a specific frame.
+  """
+  @spec get_frame(binary(), User.t()) :: Frame.t() | nil
+  def get_frame(<<_::288>> = id, %{current_org_id: organisation_id}) do
+    Repo.get_by(Frame, id: id, organisation_id: organisation_id)
+  end
+
+  def get_frame(_, _), do: nil
+
+  @doc """
+  Create a frame.
+  """
+  @spec create_frame(User.t(), map()) :: Frame.t() | {:error, Ecto.Changeset.t()}
+  def create_frame(%{id: user_id, current_org_id: organisation_id}, attrs) do
+    params =
+      Map.merge(attrs, %{
+        "organisation_id" => organisation_id,
+        "creator_id" => user_id
+      })
+
+    Multi.new()
+    |> Multi.insert(:frame, Frame.changeset(%Frame{}, params))
+    |> Multi.update(:frame_file_upload, &Frame.file_changeset(&1.frame, params))
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{frame_file_upload: frame}} -> {:ok, frame}
+      {:error, _, changeset, _} -> {:error, changeset}
+    end
+  end
+
+  @doc """
+  Update a frame.
+  """
+  @spec update_frame(Frame.t(), User.t(), map()) :: Frame.t() | {:error, Ecto.Changeset.t()}
+  def update_frame(%Frame{} = frame, %{id: user_id, current_org_id: organisation_id}, attrs) do
+    frame
+    |> Frame.update_changeset(
+      Map.merge(attrs, %{
+        "organisation_id" => organisation_id,
+        "creator_id" => user_id
+      })
+    )
+    |> Repo.update()
+  end
+
+  @doc """
+  Delete a frame.
+  """
+  @spec delete_frame(Frame.t()) :: {:ok, Frame.t()} | {:error, Ecto.Changeset.t()}
+  def delete_frame(%Frame{} = frame) do
+    case Minio.delete_file("organisations/#{frame.organisation_id}/frames/#{frame.id}") do
+      {:ok, _} ->
+        Repo.delete(frame)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+end

--- a/lib/wraft_doc/document/layout.ex
+++ b/lib/wraft_doc/document/layout.ex
@@ -16,6 +16,7 @@ defmodule WraftDoc.Document.Layout do
     field(:screenshot, WraftDocWeb.LayoutScreenShotUploader.Type)
 
     belongs_to(:engine, WraftDoc.Document.Engine)
+    belongs_to(:frame, WraftDoc.Document.Frame)
     belongs_to(:creator, WraftDoc.Account.User)
     belongs_to(:organisation, WraftDoc.Enterprise.Organisation)
 

--- a/lib/wraft_doc/document/layout.ex
+++ b/lib/wraft_doc/document/layout.ex
@@ -36,13 +36,13 @@ defmodule WraftDoc.Document.Layout do
       :height,
       :unit,
       :slug,
+      :frame_id,
       :organisation_id,
       :engine_id
     ])
     |> validate_required([
       :name,
       :description,
-      :slug,
       :organisation_id,
       :engine_id
     ])
@@ -61,13 +61,13 @@ defmodule WraftDoc.Document.Layout do
       :height,
       :unit,
       :slug,
+      :frame_id,
       :engine_id
     ])
     |> cast_attachments(attrs, [:screenshot])
     |> validate_required([
       :name,
       :description,
-      :slug,
       :engine_id
     ])
     |> unique_constraint(:name,

--- a/lib/wraft_doc/document/layout.ex
+++ b/lib/wraft_doc/document/layout.ex
@@ -13,14 +13,13 @@ defmodule WraftDoc.Document.Layout do
     field(:height, :float)
     field(:unit, :string)
     field(:slug, :string)
-    field(:slug_file, WraftDocWeb.LayoutSlugUploader.Type)
     field(:screenshot, WraftDocWeb.LayoutScreenShotUploader.Type)
+
     belongs_to(:engine, WraftDoc.Document.Engine)
     belongs_to(:creator, WraftDoc.Account.User)
     belongs_to(:organisation, WraftDoc.Enterprise.Organisation)
 
     has_many(:content_types, WraftDoc.Document.ContentType)
-
     has_many(:layout_assets, WraftDoc.Document.LayoutAsset)
     has_many(:assets, through: [:layout_assets, :asset])
 
@@ -63,7 +62,7 @@ defmodule WraftDoc.Document.Layout do
       :slug,
       :engine_id
     ])
-    |> cast_attachments(attrs, [:slug_file, :screenshot])
+    |> cast_attachments(attrs, [:screenshot])
     |> validate_required([
       :name,
       :description,
@@ -77,6 +76,6 @@ defmodule WraftDoc.Document.Layout do
   end
 
   def file_changeset(%Layout{} = layout, attrs \\ %{}) do
-    cast_attachments(layout, attrs, [:slug_file, :screenshot])
+    cast_attachments(layout, attrs, [:screenshot])
   end
 end

--- a/lib/wraft_doc_web/controllers/frame_controller.ex
+++ b/lib/wraft_doc_web/controllers/frame_controller.ex
@@ -1,0 +1,284 @@
+defmodule WraftDocWeb.Api.V1.FrameController do
+  use WraftDocWeb, :controller
+  use PhoenixSwagger
+
+  alias WraftDoc.Document.Frame
+  alias WraftDoc.Document.Frames
+
+  action_fallback(WraftDocWeb.FallbackController)
+
+  def swagger_definitions do
+    %{
+      Frame:
+        swagger_schema do
+          title("Frame")
+          description("A Frame resource")
+
+          properties do
+            id(:string, "Unique identifier for the frame", required: true)
+            name(:string, "Name of the frame", required: true)
+            inserted_at(:string, "Timestamp of frame creation", format: "ISO-8601")
+            updated_at(:string, "Timestamp of last frame update", format: "ISO-8601")
+
+            frame(
+              :object,
+              "Frame details containing the uploaded file's metadata",
+              required: true,
+              properties: %{
+                file_name: :string,
+                updated_at: :string
+              }
+            )
+          end
+
+          example(%{
+            id: "123e4567-e89b-12d3-a456-426614174000",
+            name: "my-document-frame",
+            frame: %{
+              file_name: "template.tex",
+              updated_at: "2024-11-29T12:56:47"
+            },
+            inserted_at: "2024-01-15T10:30:00Z",
+            updated_at: "2024-01-15T10:30:00Z"
+          })
+        end,
+      UpdateFrame:
+        swagger_schema do
+          title("Update Frame")
+          description("Updated Frame resource")
+
+          properties do
+            id(:string, "Unique identifier for the frame", required: true)
+            name(:string, "Updated name of the frame")
+            inserted_at(:string, "Original creation timestamp", format: "ISO-8601")
+            updated_at(:string, "Updated timestamp", format: "ISO-8601")
+
+            frame(
+              :object,
+              "Frame details containing the uploaded file's metadata",
+              required: true,
+              properties: %{
+                file_name: :string,
+                updated_at: :string
+              }
+            )
+          end
+
+          example(%{
+            id: "123e4567-e89b-12d3-a456-426614174000",
+            name: "updated-document-frame",
+            frame: %{
+              file_name: "template.tex",
+              updated_at: "2024-11-29T12:56:47"
+            },
+            inserted_at: "2024-01-15T10:30:00Z",
+            updated_at: "2024-01-16T15:45:00Z"
+          })
+        end,
+      Frames:
+        swagger_schema do
+          title("All Frames")
+          description("All frames created under current user's organisation")
+
+          type(:array)
+          items(Schema.ref(:UpdateFrame))
+        end,
+      ShowFrame:
+        swagger_schema do
+          title("Show Frame")
+          description("Details of a specific frame")
+
+          properties do
+            frame(Schema.ref(:Frame))
+          end
+
+          example(%{
+            frame: %{
+              id: "123e4567-e89b-12d3-a456-426614174000",
+              name: "my-document-frame",
+              frame: %{
+                file_name: "template.tex",
+                updated_at: "2024-11-29T12:56:47"
+              },
+              inserted_at: "2024-01-15T10:30:00Z",
+              updated_at: "2024-01-15T10:30:00Z"
+            }
+          })
+        end,
+      FrameIndex:
+        swagger_schema do
+          properties do
+            frames(Schema.ref(:Frames))
+            page_number(:integer, "Current page number")
+            total_pages(:integer, "Total number of pages")
+            total_entries(:integer, "Total number of frame entries")
+          end
+
+          example(%{
+            frames: [
+              %{
+                id: "123e4567-e89b-12d3-a456-426614174000",
+                name: "my-document-frame",
+                frame: %{
+                  file_name: "template.tex",
+                  updated_at: "2024-11-29T12:56:47"
+                },
+                inserted_at: "2024-01-15T10:30:00Z",
+                updated_at: "2024-01-15T10:30:00Z"
+              }
+            ],
+            page_number: 1,
+            total_pages: 5,
+            total_entries: 25
+          })
+        end
+    }
+  end
+
+  @doc """
+  List frames for the current user's organisation
+  """
+  swagger_path :index do
+    get("/frames")
+    summary("Frame index")
+    description("Frame index API")
+
+    parameter(:page, :query, :string, "Page number")
+    parameter(:name, :query, :string, "Frame Name")
+
+    parameter(
+      :sort,
+      :query,
+      :string,
+      "Sort Keys => name, name_desc, inserted_at, inserted_at_desc"
+    )
+
+    response(200, "Ok", Schema.ref(:FrameIndex))
+    response(401, "Unauthorized", Schema.ref(:Error))
+  end
+
+  def index(conn, params) do
+    current_user = conn.assigns[:current_user]
+
+    with %{
+           entries: frames,
+           page_number: page_number,
+           total_pages: total_pages,
+           total_entries: total_entries
+         } <- Frames.list_frames(current_user, params) do
+      render(conn, "index.json",
+        frames: frames,
+        page_number: page_number,
+        total_pages: total_pages,
+        total_entries: total_entries
+      )
+    end
+  end
+
+  @doc """
+  Create a new frame
+  """
+  swagger_path :create do
+    post("/frames")
+    summary("Create a new frame")
+    description("Create a new frame API")
+    consumes("multipart/form-data")
+
+    parameters do
+      name(:formData, :string, "Frame name", required: true)
+      frame(:formData, :file, "Frame file to upload", required: true)
+    end
+
+    response(200, "Created", Schema.ref(:Frame))
+    response(422, "Unprocessable Entity", Schema.ref(:Error))
+    response(401, "Unauthorized", Schema.ref(:Error))
+  end
+
+  def create(conn, params) do
+    current_user = conn.assigns[:current_user]
+
+    with {:ok, %Frame{} = frame} <- Frames.create_frame(current_user, params) do
+      render(conn, "create.json", frame: frame)
+    end
+  end
+
+  @doc """
+  Show a specific frame
+  """
+  swagger_path :show do
+    get("/frames/{id}")
+    summary("Show a frame")
+    description("Show a frame API")
+
+    parameters do
+      id(:path, :string, "frame id", required: true)
+    end
+
+    response(200, "Ok", Schema.ref(:ShowFrame))
+    response(401, "Unauthorized", Schema.ref(:Error))
+    response(404, "Not Found", Schema.ref(:Error))
+  end
+
+  def show(conn, %{"id" => id}) do
+    current_user = conn.assigns.current_user
+
+    with %Frame{} = frame <- Frames.get_frame(id, current_user) do
+      render(conn, "show.json", frame: frame)
+    end
+  end
+
+  @doc """
+  Update a frame
+  """
+  swagger_path :update do
+    put("/frames/{id}")
+    summary("Update a frame")
+    description("Update a frame API")
+    consumes("multipart/form-data")
+
+    parameter(:id, :path, :string, "frame id", required: true)
+    parameter(:name, :formData, :string, "Frame's name")
+    parameter(:frame, :formData, :file, "Frame file to upload")
+
+    response(200, "Ok", Schema.ref(:UpdateFrame))
+    response(404, "Not found", Schema.ref(:Error))
+    response(422, "Unprocessable Entity", Schema.ref(:Error))
+    response(401, "Unauthorized", Schema.ref(:Error))
+  end
+
+  def update(conn, %{"id" => frame_uuid} = params) do
+    current_user = conn.assigns[:current_user]
+
+    with %Frame{} = existing_frame <- Frames.get_frame(frame_uuid, current_user),
+         {:ok, %Frame{} = updated_frame} <-
+           Frames.update_frame(existing_frame, current_user, params) do
+      render(conn, "create.json", frame: updated_frame)
+    end
+  end
+
+  @doc """
+  Delete a frame
+  """
+  swagger_path :delete do
+    PhoenixSwagger.Path.delete("/frames/{id}")
+    summary("Delete a frame")
+    description("API to delete a frame")
+
+    parameters do
+      id(:path, :string, "frame id", required: true)
+    end
+
+    response(200, "Ok", Schema.ref(:Frame))
+    response(422, "Unprocessable Entity", Schema.ref(:Error))
+    response(401, "Unauthorized", Schema.ref(:Error))
+  end
+
+  def delete(conn, %{"id" => uuid}) do
+    current_user = conn.assigns[:current_user]
+
+    with %Frame{} = frame <- Frames.get_frame(uuid, current_user),
+         {:ok, %Frame{}} <- Frames.delete_frame(frame) do
+      render(conn, "create.json", frame: frame)
+    end
+  end
+end

--- a/lib/wraft_doc_web/controllers/frame_controller.ex
+++ b/lib/wraft_doc_web/controllers/frame_controller.ex
@@ -256,10 +256,10 @@ defmodule WraftDocWeb.Api.V1.FrameController do
   def update(conn, %{"id" => frame_uuid} = params) do
     current_user = conn.assigns[:current_user]
 
-    with %Frame{} = existing_frame <- Frames.get_frame(frame_uuid, current_user),
-         {:ok, %Frame{} = updated_frame} <-
-           Frames.update_frame(existing_frame, current_user, params) do
-      render(conn, "create.json", frame: updated_frame)
+    with %Frame{} = frame <- Frames.get_frame(frame_uuid, current_user),
+         {:ok, %Frame{} = frame} <-
+           Frames.update_frame(frame, current_user, params) do
+      render(conn, "create.json", frame: frame)
     end
   end
 

--- a/lib/wraft_doc_web/controllers/frame_controller.ex
+++ b/lib/wraft_doc_web/controllers/frame_controller.ex
@@ -2,10 +2,17 @@ defmodule WraftDocWeb.Api.V1.FrameController do
   use WraftDocWeb, :controller
   use PhoenixSwagger
 
-  alias WraftDoc.Document.Frame
-  alias WraftDoc.Document.Frames
+  plug WraftDocWeb.Plug.Authorized,
+    create: "frame:manage",
+    index: "frame:show",
+    show: "frame:show",
+    update: "frame:manage",
+    delete: "frame:delete"
 
   action_fallback(WraftDocWeb.FallbackController)
+
+  alias WraftDoc.Document.Frame
+  alias WraftDoc.Document.Frames
 
   def swagger_definitions do
     %{

--- a/lib/wraft_doc_web/controllers/layout_controller.ex
+++ b/lib/wraft_doc_web/controllers/layout_controller.ex
@@ -73,7 +73,16 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
             height: 20.0,
             unit: "cm",
             slug: "Pandoc",
-            frame_id: "1232148nb3478",
+            frame: %{
+              id: "123e4567-e89b-12d3-a456-426614174000",
+              name: "my-document-frame",
+              frame: %{
+                file_name: "template.tex",
+                updated_at: "2024-11-29T12:56:47"
+              },
+              inserted_at: "2024-01-15T10:30:00Z",
+              updated_at: "2024-01-15T10:30:00Z"
+            },
             screenshot: "/official_letter.jpg",
             updated_at: "2020-01-21T14:00:00Z",
             inserted_at: "2020-02-21T14:00:00Z"
@@ -108,8 +117,17 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
             height: 20.0,
             unit: "cm",
             slug: "Pandoc",
-            frame_id: "1232148nb3478",
             screenshot: "/official_letter.jpg",
+            frame: %{
+              id: "123e4567-e89b-12d3-a456-426614174000",
+              name: "my-document-frame",
+              frame: %{
+                file_name: "template.tex",
+                updated_at: "2024-11-29T12:56:47"
+              },
+              inserted_at: "2024-01-15T10:30:00Z",
+              updated_at: "2024-01-15T10:30:00Z"
+            },
             engine: %{
               id: "1232148nb3478",
               name: "Pandoc",
@@ -156,8 +174,17 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
               height: 20.0,
               unit: "cm",
               slug: "Pandoc",
-              frame_id: "1232148nb3478",
               screenshot: "/official_letter.jpg",
+              frame: %{
+                id: "123e4567-e89b-12d3-a456-426614174000",
+                name: "my-document-frame",
+                frame: %{
+                  file_name: "template.tex",
+                  updated_at: "2024-11-29T12:56:47"
+                },
+                inserted_at: "2024-01-15T10:30:00Z",
+                updated_at: "2024-01-15T10:30:00Z"
+              },
               engine: %{
                 id: "1232148nb3478",
                 name: "Pandoc",
@@ -197,7 +224,16 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
                 height: 20.0,
                 unit: "cm",
                 slug: "Pandoc",
-                frame_id: "1232148nb3478",
+                frame: %{
+                  id: "123e4567-e89b-12d3-a456-426614174000",
+                  name: "my-document-frame",
+                  frame: %{
+                    file_name: "template.tex",
+                    updated_at: "2024-11-29T12:56:47"
+                  },
+                  inserted_at: "2024-01-15T10:30:00Z",
+                  updated_at: "2024-01-15T10:30:00Z"
+                },
                 screenshot: "/official_letter.jpg",
                 engine: %{
                   id: "1232148nb3478",

--- a/lib/wraft_doc_web/controllers/layout_controller.ex
+++ b/lib/wraft_doc_web/controllers/layout_controller.ex
@@ -59,7 +59,7 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
             height(:float, "Height of the layout")
             unit(:string, "Unit of dimensions")
             slug(:string, "Name of the slug to be used for the layout")
-            slug_file(:string, "URL of the uploaded slug file")
+            frame_id(:string, "The ID of the layout")
             screenshot(:string, "URL of the uploaded screenshot")
             inserted_at(:string, "When was the layout created", format: "ISO-8601")
             updated_at(:string, "When was the layout last updated", format: "ISO-8601")
@@ -73,7 +73,7 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
             height: 20.0,
             unit: "cm",
             slug: "Pandoc",
-            slug_file: "/official_letter.zip",
+            frame_id: "1232148nb3478",
             screenshot: "/official_letter.jpg",
             updated_at: "2020-01-21T14:00:00Z",
             inserted_at: "2020-02-21T14:00:00Z"
@@ -92,7 +92,7 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
             height(:float, "Height of the layout")
             unit(:string, "Unit of dimensions")
             slug(:string, "Name of the slug to be used for the layout")
-            slug_file(:string, "URL of the uploaded slug file")
+            frame_id(:string, "The ID of the layout")
             screenshot(:string, "URL of the uploaded screenshot")
             engine(Schema.ref(:Engine))
             assets(Schema.ref(:Assets))
@@ -108,7 +108,7 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
             height: 20.0,
             unit: "cm",
             slug: "Pandoc",
-            slug_file: "/official_letter.zip",
+            frame_id: "1232148nb3478",
             screenshot: "/official_letter.jpg",
             engine: %{
               id: "1232148nb3478",
@@ -156,7 +156,7 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
               height: 20.0,
               unit: "cm",
               slug: "Pandoc",
-              slug_file: "/official_letter.zip",
+              frame_id: "1232148nb3478",
               screenshot: "/official_letter.jpg",
               engine: %{
                 id: "1232148nb3478",
@@ -197,7 +197,7 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
                 height: 20.0,
                 unit: "cm",
                 slug: "Pandoc",
-                slug_file: "/official_letter.zip",
+                frame_id: "1232148nb3478",
                 screenshot: "/official_letter.jpg",
                 engine: %{
                   id: "1232148nb3478",
@@ -244,7 +244,7 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
 
     parameter(:slug, :formData, :string, "Name of slug to be used")
 
-    parameter(:slug_file, :formData, :file, "Slug file to upload")
+    parameter(:frame_id, :formData, :string, "ID of the frame")
 
     parameter(:screenshot, :formData, :file, "Screenshot to upload", required: true)
 
@@ -362,7 +362,7 @@ defmodule WraftDocWeb.Api.V1.LayoutController do
 
     parameter(:slug, :formData, :string, "Name of slug to be used")
 
-    parameter(:slug_file, :formData, :file, "Slug file to upload")
+    parameter(:frame_id, :formData, :string, "Slug file to upload")
 
     parameter(:screenshot, :formData, :file, "Screenshot to upload", required: true)
 

--- a/lib/wraft_doc_web/router.ex
+++ b/lib/wraft_doc_web/router.ex
@@ -178,6 +178,7 @@ defmodule WraftDocWeb.Router do
 
       # Enginebody
       resources("/engines", EngineController, only: [:index])
+      resources("/frames", FrameController)
 
       scope "/forms" do
         # Forms

--- a/lib/wraft_doc_web/uploaders/frame_uploader.ex
+++ b/lib/wraft_doc_web/uploaders/frame_uploader.ex
@@ -1,0 +1,34 @@
+defmodule WraftDocWeb.FrameUploader do
+  @moduledoc false
+
+  use Waffle.Definition
+  use Waffle.Ecto.Definition
+
+  @versions [:original]
+  @extension_whitelist ~w(.tex)
+
+  def validate({file, _}) do
+    file_extension =
+      file.file_name
+      |> Path.extname()
+      |> String.downcase()
+
+    @extension_whitelist
+    |> Enum.member?(file_extension)
+    |> case do
+      true -> :ok
+      false -> {:error, "Invalid tex file."}
+    end
+  end
+
+  def filename(_version, {file, _template}) do
+    String.replace("frame_" <> Path.rootname(file.file_name, ".tex"), ~r/\s+/, "-")
+  end
+
+  def storage_dir(_version, {_file, scope}) do
+    case scope.organisation_id do
+      nil -> "public/frames"
+      _ -> "organisations/#{scope.organisation_id}/frames/#{scope.id}"
+    end
+  end
+end

--- a/lib/wraft_doc_web/uploaders/frame_uploader.ex
+++ b/lib/wraft_doc_web/uploaders/frame_uploader.ex
@@ -4,6 +4,8 @@ defmodule WraftDocWeb.FrameUploader do
   use Waffle.Definition
   use Waffle.Ecto.Definition
 
+  # alias WraftDoc.Document.Frames
+
   @versions [:original]
   @extension_whitelist ~w(.tex)
 
@@ -16,8 +18,14 @@ defmodule WraftDocWeb.FrameUploader do
     @extension_whitelist
     |> Enum.member?(file_extension)
     |> case do
-      true -> :ok
-      false -> {:error, "Invalid tex file."}
+      true ->
+        :ok
+
+      false ->
+        {:error, "Invalid tex file."}
+        # with {:ok, _} <- Frames.validate_latex_file(file) do
+        #   :ok
+        # end
     end
   end
 

--- a/lib/wraft_doc_web/uploaders/frame_uploader.ex
+++ b/lib/wraft_doc_web/uploaders/frame_uploader.ex
@@ -4,7 +4,7 @@ defmodule WraftDocWeb.FrameUploader do
   use Waffle.Definition
   use Waffle.Ecto.Definition
 
-  # alias WraftDoc.Document.Frames
+  alias WraftDoc.Document.Frame
 
   @versions [:original]
   @extension_whitelist ~w(.tex)
@@ -23,9 +23,6 @@ defmodule WraftDocWeb.FrameUploader do
 
       false ->
         {:error, "Invalid tex file."}
-        # with {:ok, _} <- Frames.validate_latex_file(file) do
-        #   :ok
-        # end
     end
   end
 
@@ -33,10 +30,7 @@ defmodule WraftDocWeb.FrameUploader do
     String.replace("frame_" <> Path.rootname(file.file_name, ".tex"), ~r/\s+/, "-")
   end
 
-  def storage_dir(_version, {_file, scope}) do
-    case scope.organisation_id do
-      nil -> "public/frames"
-      _ -> "organisations/#{scope.organisation_id}/frames/#{scope.id}"
-    end
+  def storage_dir(_version, {_file, %Frame{id: id, organisation_id: organisation_id}}) do
+    "organisations/#{organisation_id}/frames/#{id}"
   end
 end

--- a/lib/wraft_doc_web/views/frame_view.ex
+++ b/lib/wraft_doc_web/views/frame_view.ex
@@ -1,0 +1,35 @@
+defmodule WraftDocWeb.Api.V1.FrameView do
+  use WraftDocWeb, :view
+
+  alias __MODULE__
+
+  def render("create.json", %{frame: frame}) do
+    %{
+      id: frame.id,
+      name: frame.name,
+      frame_file: frame.frame_file,
+      updated_at: frame.updated_at,
+      inserted_at: frame.inserted_at
+    }
+  end
+
+  def render("index.json", %{
+        frames: frames,
+        page_number: page_number,
+        total_pages: total_pages,
+        total_entries: total_entries
+      }) do
+    %{
+      frames: render_many(frames, FrameView, "create.json", as: :frame),
+      page_number: page_number,
+      total_pages: total_pages,
+      total_entries: total_entries
+    }
+  end
+
+  def render("show.json", %{frame: frame}) do
+    %{
+      frame: render_one(frame, FrameView, "create.json", as: :frame)
+    }
+  end
+end

--- a/lib/wraft_doc_web/views/layout_view.ex
+++ b/lib/wraft_doc_web/views/layout_view.ex
@@ -14,7 +14,6 @@ defmodule WraftDocWeb.Api.V1.LayoutView do
       height: layout.height,
       unit: layout.unit,
       slug: layout.slug,
-      slug_file: generate_url(layout),
       screenshot: generate_ss_url(layout),
       inserted_at: layout.inserted_at,
       update_at: layout.updated_at,
@@ -32,7 +31,6 @@ defmodule WraftDocWeb.Api.V1.LayoutView do
       height: layout.height,
       unit: layout.unit,
       slug: layout.slug,
-      slug_file: generate_url(layout),
       screenshot: generate_ss_url(layout),
       inserted_at: layout.inserted_at,
       update_at: layout.updated_at
@@ -58,10 +56,6 @@ defmodule WraftDocWeb.Api.V1.LayoutView do
       layout: render_one(layout, LayoutView, "create.json", as: :doc_layout),
       creator: render_one(layout.creator, UserView, "user.json", as: :user)
     }
-  end
-
-  defp generate_url(%{slug_file: file} = layout) do
-    WraftDocWeb.LayoutSlugUploader.url({file, layout}, signed: true)
   end
 
   defp generate_ss_url(%{screenshot: file} = layout) do

--- a/lib/wraft_doc_web/views/layout_view.ex
+++ b/lib/wraft_doc_web/views/layout_view.ex
@@ -1,7 +1,9 @@
 defmodule WraftDocWeb.Api.V1.LayoutView do
   use WraftDocWeb, :view
+  alias WraftDoc.Document.Layout
   alias WraftDocWeb.Api.V1.AssetView
   alias WraftDocWeb.Api.V1.EngineView
+  alias WraftDocWeb.Api.V1.FrameView
   alias WraftDocWeb.Api.V1.UserView
   alias __MODULE__
 
@@ -14,6 +16,7 @@ defmodule WraftDocWeb.Api.V1.LayoutView do
       height: layout.height,
       unit: layout.unit,
       slug: layout.slug,
+      frame: render_frame(layout),
       screenshot: generate_ss_url(layout),
       inserted_at: layout.inserted_at,
       update_at: layout.updated_at,
@@ -61,4 +64,10 @@ defmodule WraftDocWeb.Api.V1.LayoutView do
   defp generate_ss_url(%{screenshot: file} = layout) do
     WraftDocWeb.LayoutScreenShotUploader.url({file, layout}, signed: true)
   end
+
+  # HACK: Handle nil case of frame, frame is optional.
+  defp render_frame(%Layout{frame: %WraftDoc.Document.Frame{} = frame}),
+    do: render_one(frame, FrameView, "create.json", as: :frame)
+
+  defp render_frame(_), do: nil
 end

--- a/priv/repo/data/rbac/permissions.csv
+++ b/priv/repo/data/rbac/permissions.csv
@@ -88,9 +88,12 @@ form:delete,Form,Delete
 form_entry:show,Form Entry,Show
 form_entry:manage,Form Entry,Manage
 form_entry:delete,Form Entry,Delete
-template_asset:show,TemplateAsset,Show
 form_mapping:manage,Form Mapping,Manage
 form_mapping:show,Form Mapping,Show
+template_asset:show,TemplateAsset,Show
 template_asset:manage,TemplateAsset,Manage
 template_asset:delete,TemplateAsset,Delete
 dashboard:show,DashBoard,Show
+frame:show,Frame,Show
+frame:manage,Frame,Manage
+frame:delete,Frame,Delete

--- a/priv/repo/migrations/20241202170324_create_frame_table_and_associate_with_layout.exs
+++ b/priv/repo/migrations/20241202170324_create_frame_table_and_associate_with_layout.exs
@@ -1,0 +1,20 @@
+defmodule WraftDoc.Repo.Migrations.CreateFrameTableAndAssociateWithLayout do
+  use Ecto.Migration
+
+  def change do
+    create table(:frame, primary_key: false) do
+      add(:id, :uuid, primary_key: true)
+      add(:name, :string)
+      add(:frame_file, :string)
+
+      add(
+        :organisation_id,
+        references(:organisation, type: :uuid, column: :id, on_delete: :nilify_all)
+      )
+
+      add(:creator_id, references(:user, type: :uuid, column: :id, on_delete: :nothing))
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20241202170324_create_frame_table_and_associate_with_layout.exs
+++ b/priv/repo/migrations/20241202170324_create_frame_table_and_associate_with_layout.exs
@@ -16,5 +16,15 @@ defmodule WraftDoc.Repo.Migrations.CreateFrameTableAndAssociateWithLayout do
 
       timestamps()
     end
+
+    create(
+      unique_index(:frame, [:name, :organisation_id], name: :frame_name_organisation_id_index)
+    )
+
+    alter table(:layout) do
+      remove(:slug_file)
+
+      add(:frame_id, references(:frame, type: :uuid, column: :id, on_delete: :nilify_all))
+    end
   end
 end


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [x] Feature addition
- [x] Refactoring

## Description

This feature helps to upload customized frames(slugs) which we can use as template in build document.
user can upload latex file, can be select while creating layout and used at building document

## How Has This Been Tested?

By postman and swagger api

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.
