### PR TITLE
feat: allow superadmin to see all documents

### DIFF
--- a/lib/wraft_doc/document/document.ex
+++ b/lib/wraft_doc/document/document.ex
@@ -987,14 +987,12 @@ defmodule WraftDoc.Document do
         %{current_org_id: org_id, role_names: role_names} = current_user,
         params
       ) do
-    is_superadmin = "superadmin" in role_names
-
     Instance
     |> join(:inner, [i], ct in ContentType,
       on: ct.organisation_id == ^org_id and i.content_type_id == ct.id,
       as: :content_type
     )
-    |> superadmin_check(is_superadmin, current_user)
+    |> superadmin_check("superadmin" in role_names, current_user)
     |> where(^instance_index_filter_by_instance_id(params))
     |> where(^instance_index_filter_by_content_type_name(params))
     |> where(^instance_index_filter_by_instance_title(params))

--- a/lib/wraft_doc/document/document.ex
+++ b/lib/wraft_doc/document/document.ex
@@ -1011,7 +1011,13 @@ defmodule WraftDoc.Document do
 
   def instance_index_of_an_organisation(_, _), do: {:error, :invalid_id}
 
-  defp superadmin_check(query, true, _), do: query
+  defp superadmin_check(query, true, current_user) do
+    where(
+      query,
+      [i],
+      (is_nil(i.state_id) and i.creator_id == ^current_user.id) or not is_nil(i.state_id)
+    )
+  end
 
   defp superadmin_check(query, false, current_user),
     do: where(query, [i], ^current_user.id in i.allowed_users)

--- a/lib/wraft_doc/document/document.ex
+++ b/lib/wraft_doc/document/document.ex
@@ -984,10 +984,9 @@ defmodule WraftDoc.Document do
   """
   @spec instance_index_of_an_organisation(User.t(), map) :: map
   def instance_index_of_an_organisation(%{current_org_id: org_id} = current_user, params) do
-    is_superadmin =
-      Enum.any?(current_user.user_roles, fn user_role ->
-        user_role.role == org_id and user_role.role.name == "superadmin"
-      end)
+    role_names = current_user.role_names
+
+    is_superadmin = "superadmin" in role_names
 
     base_query =
       Instance


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [x] Feature addition
- [x] Bug fix


## Description

- allow super admin view all for document (content) , from dashboard in the organisation 
- only the document creator can see the initial state  document (content) 

## Motivation and Context
it solve the problem where super admin is  only able to see the document made by them 

## How Has This Been Tested?

it was tested in localhost with different accounts

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.

