### PR TITLE
fix: failure in table creation

### DIFF
--- a/priv/slugs/contract/template.tex
+++ b/priv/slugs/contract/template.tex
@@ -58,7 +58,7 @@ $if(mainfont)$
   $endif$
 
   % Longtabe and friends
-  \usepackage{rotating,multirow,longtable,booktabs}
+  \usepackage{rotating,multirow,longtable,booktabs,calc,array}
 
   % Polyglossia settings
   \setmainlanguage{english} % or danish

--- a/priv/slugs/pletter/template.tex
+++ b/priv/slugs/pletter/template.tex
@@ -147,7 +147,7 @@ $if(highlighting-macros)$
 $highlighting-macros$
 $endif$
 $if(tables)$
-\usepackage{longtable,booktabs}
+\usepackage{longtable,booktabs,array,calc}
 % Fix footnotes in tables (requires footnote package)
 \IfFileExists{footnote.sty}{\usepackage{footnote}\makesavenoteenv{longtable}}{}
 $endif$


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [ ] Feature addition
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please specify)

## Description

Tables were not generated in certain scenarios on attempting to generate document.

## Fixes

The issue was due to using the pandoc version 2.17.1.1 . The document would generate in version 2.9. 
So on changing the pandoc version to latest version as of now which is 3.6 and adding the missing packages namely array and calc and subsequently attempting to generate the document has fixed the issue.

## Motivation and Context

It would be not possible to generate document in specific scenarios where document template has tables.

## How Has This Been Tested?

The issue has been tested from wraft-ui as well as a sandboxed environment created to debug, test and fix pandoc related issues.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.
