### PR TITLE
fix: update unique index and add double entries for initial versioning

### DIFF
--- a/lib/wraft_doc/document/document.ex
+++ b/lib/wraft_doc/document/document.ex
@@ -586,7 +586,6 @@ defmodule WraftDoc.Document do
   defp create_initial_version(%{id: author_id}, %Instance{id: document_id} = instance) do
     params = %{
       "version_number" => 1,
-      "type" => "save",
       "naration" => "Initial version",
       "raw" => instance.raw,
       "serialized" => instance.serialized,
@@ -596,15 +595,20 @@ defmodule WraftDoc.Document do
 
     Logger.info("Creating initial version...")
 
-    %Version{}
-    |> Version.changeset(params)
-    |> Repo.insert!()
+    insert_initial_version(Map.merge(params, %{"type" => "save"}))
+    insert_initial_version(Map.merge(params, %{"type" => "build"}))
 
     Logger.info("Initial version generated")
     {:ok, "ok"}
   end
 
   defp create_initial_version(_, _), do: {:error, :invalid}
+
+  defp insert_initial_version(params) do
+    %Version{}
+    |> Version.changeset(params)
+    |> Repo.insert!()
+  end
 
   @doc """
   Same as create_instance/4, to create instance and its approval system

--- a/lib/wraft_doc/document/instance_version.ex
+++ b/lib/wraft_doc/document/instance_version.ex
@@ -22,5 +22,9 @@ defmodule WraftDoc.Document.Instance.Version do
     version
     |> cast(attrs, @fields)
     |> validate_required(@fields -- [:naration, :content_id])
+    |> unique_constraint(:version_number,
+      name: :version_unique_index,
+      message: "Version number already exists"
+    )
   end
 end

--- a/priv/repo/migrations/20250211092817_update_version_unique_index.exs
+++ b/priv/repo/migrations/20250211092817_update_version_unique_index.exs
@@ -1,0 +1,13 @@
+defmodule WraftDoc.Repo.Migrations.UpdateVersionUniqueIndex do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(
+      unique_index(:version, [:version_number, :content_id], name: :version_unique_index)
+    )
+
+    create(
+      unique_index(:version, [:version_number, :content_id, :type], name: :version_unique_index)
+    )
+  end
+end


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [ ] Feature addition
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please specify)

## Description

* Added a initial version while building as well as while saving the document.
* Added unique index between content_id, version number and type.

## Motivation and Context

* Ensures that the correct version of the document can be downloaded.

Why is this change required? What problem does it solve?

* It ensures that the correct document version can be downloaded with correct filenaming. 

## How Has This Been Tested?

* Tested through UI but creating a document and saving as well as generating builds and successively attempting to download the document.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.