### PR TITLE
fix: organisation filter bugs and data_template renamed

### DIFF
--- a/lib/wraft_doc/document/data_template.ex
+++ b/lib/wraft_doc/document/data_template.ex
@@ -28,7 +28,7 @@ defmodule WraftDoc.Document.DataTemplate do
     %{
       fields: [
         %{name: "id", type: "string", facet: false},
-        %{name: "title", type: "string", facet: true},
+        %{name: "name", type: "string", facet: true},
         %{name: "title_template", type: "string", facet: true},
         %{name: "data", type: "string", facet: true},
         %{name: "serialized", type: "string", facet: false},

--- a/lib/wraft_doc/search/encoder.ex
+++ b/lib/wraft_doc/search/encoder.ex
@@ -48,7 +48,7 @@ defimpl WraftDoc.Search.Encoder, for: WraftDoc.Document.DataTemplate do
     %{
       id: to_string(data_template.id),
       collection_name: "data_template",
-      title: data_template.title,
+      name: data_template.title,
       title_template: data_template.title_template,
       data: data_template.data,
       serialized: Jason.encode!(data_template.serialized),

--- a/lib/wraft_doc/search/typesense.ex
+++ b/lib/wraft_doc/search/typesense.ex
@@ -95,34 +95,6 @@ defmodule WraftDoc.Search.Typesense do
 
   If no collection name is provided, the search is executed across predefined collections.
   """
-  def x_search(params, org_id \\ nil) do
-    # org_id = conn.assigns[:current_user].current_org_id
-    query = Map.get(params, "query", "")
-    collection = Map.get(params, "collection")
-
-    opts =
-      Enum.reduce(WraftDoc.Search.Presets.default_search_opts(), %{}, fn {key, default_value},
-                                                                         acc ->
-        param_value = Map.get(params, Atom.to_string(key))
-        Map.put(acc, key, param_value || default_value)
-      end)
-
-    opts = Map.put(opts, :filter_by, org_id)
-
-    case search(query, collection, opts) do
-      {:ok, results} ->
-        results
-
-      # render(conn, "search.json", results: results)
-
-      {:error, reason} ->
-        reason
-        # conn
-        # |> put_status(:bad_request)
-        # |> json(%{error: reason})
-    end
-  end
-
   @spec search(String.t(), String.t() | nil, keyword()) :: {:ok, map()} | {:error, any()}
   def search(query, collection_name \\ nil, opts \\ []) do
     collection_names = ["content_type", "theme", "layout", "flow", "data_template"]

--- a/lib/wraft_doc/search/typesense.ex
+++ b/lib/wraft_doc/search/typesense.ex
@@ -131,14 +131,3 @@ defmodule WraftDoc.Search.Typesense do
     end
   end
 end
-
-%{
-  prefix: true,
-  sort_by: nil,
-  q: "the",
-  page: 1,
-  filter_by: nil,
-  per_page: 10,
-  collection_name: "data_template",
-  query_by: "title"
-}

--- a/lib/wraft_doc_web/controllers/search_controller.ex
+++ b/lib/wraft_doc_web/controllers/search_controller.ex
@@ -117,23 +117,4 @@ defmodule WraftDocWeb.Api.V1.SearchController do
         |> json(%{error: reason})
     end
   end
-
-  swagger_path :reindex do
-    get("/reindex")
-    summary("Typesense Reindex")
-    description("Reindexing Data from Typesense")
-    operation_id("reindexing")
-
-    response(200, "Ok", Schema.ref(:TypenseSearchResponse))
-    response(400, "Bad Request", Schema.ref(:Error))
-  end
-
-  @doc """
-  Recreate collections and reindex them in Typesense .
-  """
-  @spec reindex(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def reindex(conn, _params) do
-    Typesense.initialize()
-    json(conn, %{status: "success", message: "Collections initialized and data reindexed"})
-  end
 end

--- a/lib/wraft_doc_web/controllers/search_controller.ex
+++ b/lib/wraft_doc_web/controllers/search_controller.ex
@@ -93,8 +93,8 @@ defmodule WraftDocWeb.Api.V1.SearchController do
   merged from default presets and request parameters.
   """
   @spec search(conn :: Phoenix.Conn.t(), params :: map()) :: Phoenix.Conn.t()
-  def search(conn, params) do
-    org_id = "organisation_id:=#{conn.assigns[:current_user].current_org_id}"
+  def search(%{assigns: %{current_user: %{current_org_id: org_id}}} = conn, params) do
+    org_id = "organisation_id:=#{org_id}"
     query = Map.get(params, "query", "")
     collection = Map.get(params, "collection")
 
@@ -123,17 +123,16 @@ defmodule WraftDocWeb.Api.V1.SearchController do
     description("Reindexing Data from Typesense")
     operation_id("reindexing")
 
-    response(200, "OK")
+    response(200, %{status: "success", message: "Collections initialized and data reindexed"})
     response(400, "Bad Request", Schema.ref(:Error))
   end
 
   @doc """
   Recreate collections and reindex them in Typesense .
   """
-
+  @spec reindex(Plug.Conn.t(), map) :: Plug.Conn.t()
   def reindex(conn, _params) do
-    with :ok <- Typesense.initialize() do
-      json(conn, %{status: "success", message: "Collections initialized and data reindexed"})
-    end
+    Typesense.initialize()
+    json(conn, %{status: "success", message: "Collections initialized and data reindexed"})
   end
 end

--- a/lib/wraft_doc_web/controllers/search_controller.ex
+++ b/lib/wraft_doc_web/controllers/search_controller.ex
@@ -94,7 +94,7 @@ defmodule WraftDocWeb.Api.V1.SearchController do
   """
   @spec search(conn :: Phoenix.Conn.t(), params :: map()) :: Phoenix.Conn.t()
   def search(conn, params) do
-    org_id = conn.assigns[:current_user].current_org_id
+    org_id = "organisation_id:=#{conn.assigns[:current_user].current_org_id}"
     query = Map.get(params, "query", "")
     collection = Map.get(params, "collection")
 
@@ -114,6 +114,26 @@ defmodule WraftDocWeb.Api.V1.SearchController do
         conn
         |> put_status(:bad_request)
         |> json(%{error: reason})
+    end
+  end
+
+  swagger_path :reindex do
+    get("/search/reindex")
+    summary("Typesense Reindex")
+    description("Reindexing Data from Typesense")
+    operation_id("reindexing")
+
+    response(200, "OK")
+    response(400, "Bad Request", Schema.ref(:Error))
+  end
+
+  @doc """
+  Recreate collections and reindex them in Typesense .
+  """
+
+  def reindex(conn, _params) do
+    with :ok <- Typesense.initialize() do
+      json(conn, %{status: "success", message: "Collections initialized and data reindexed"})
     end
   end
 end

--- a/lib/wraft_doc_web/controllers/search_controller.ex
+++ b/lib/wraft_doc_web/controllers/search_controller.ex
@@ -118,7 +118,7 @@ defmodule WraftDocWeb.Api.V1.SearchController do
   end
 
   swagger_path :reindex do
-    get("/search/reindex")
+    get("/reindex")
     summary("Typesense Reindex")
     description("Reindexing Data from Typesense")
     operation_id("reindexing")

--- a/lib/wraft_doc_web/controllers/search_controller.ex
+++ b/lib/wraft_doc_web/controllers/search_controller.ex
@@ -92,7 +92,7 @@ defmodule WraftDocWeb.Api.V1.SearchController do
   Performs a search based on the provided query and collection, with options
   merged from default presets and request parameters.
   """
-  @spec search(conn :: Phoenix.Conn.t(), params :: map()) :: Phoenix.Conn.t()
+  @spec search(conn :: Plug.Conn.t(), params :: map()) :: Plug.Conn.t()
   def search(%{assigns: %{current_user: %{current_org_id: org_id}}} = conn, params) do
     org_filter = "organisation_id:=#{org_id}"
 
@@ -124,7 +124,7 @@ defmodule WraftDocWeb.Api.V1.SearchController do
     description("Reindexing Data from Typesense")
     operation_id("reindexing")
 
-    response(200, %{status: "success", message: "Collections initialized and data reindexed"})
+    response(200, "Ok", Schema.ref(:TypenseSearchResponse))
     response(400, "Bad Request", Schema.ref(:Error))
   end
 

--- a/lib/wraft_doc_web/router.ex
+++ b/lib/wraft_doc_web/router.ex
@@ -413,6 +413,7 @@ defmodule WraftDocWeb.Router do
 
       # Search
       get("/search", SearchController, :search)
+      get("/reindex", SearchController, :reindex)
 
       # post("/approval_systems/:id/approve", ApprovalSystemController, :approve)
 

--- a/lib/wraft_doc_web/router.ex
+++ b/lib/wraft_doc_web/router.ex
@@ -413,7 +413,6 @@ defmodule WraftDocWeb.Router do
 
       # Search
       get("/search", SearchController, :search)
-      get("/reindex", SearchController, :reindex)
 
       # post("/approval_systems/:id/approve", ApprovalSystemController, :approve)
 


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [x] Feature addition
- [x] Bug fix

## Description
- fixed the organisation bug
- changed the name from title to name in data_template  in typesense for easier uses, 
- created a new api for reindexing funtion which remove previous collection , created and then  reindex  typesense

## Motivation and Context

to make it easier for frontend to handle for  data_template

## How Has This Been Tested?

via terminal and frontend

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.

