### PR TITLE
feat: validate regular font file at create update theme

### DIFF
--- a/lib/wraft_doc/document/document.ex
+++ b/lib/wraft_doc/document/document.ex
@@ -1463,7 +1463,7 @@ defmodule WraftDoc.Document do
       |> Theme.changeset(params)
     )
     |> Multi.run(:theme_assets, fn _repo, %{theme: theme} ->
-      case fetch_and_associcate_assets_with_theme(theme, current_user, params) do
+      case fetch_and_associate_assets_with_theme(theme, current_user, params) do
         {:ok, assets} ->
           theme_preview_file_upload(theme, params)
           {:ok, assets}
@@ -1482,14 +1482,14 @@ defmodule WraftDoc.Document do
     end
   end
 
-  defp fetch_and_associcate_assets_with_theme(
+  defp fetch_and_associate_assets_with_theme(
          theme,
          current_user,
          params,
          existing_asset_ids \\ []
        )
 
-  defp fetch_and_associcate_assets_with_theme(
+  defp fetch_and_associate_assets_with_theme(
          theme,
          current_user,
          %{"assets" => assets},
@@ -1512,7 +1512,7 @@ defmodule WraftDoc.Document do
     end
   end
 
-  defp fetch_and_associcate_assets_with_theme(
+  defp fetch_and_associate_assets_with_theme(
          _theme,
          _current_user,
          _params,
@@ -1625,7 +1625,7 @@ defmodule WraftDoc.Document do
     Multi.new()
     |> Multi.update(:theme, Theme.update_changeset(theme, params))
     |> Multi.run(:theme_assets, fn _repo, %{theme: theme} ->
-      case fetch_and_associcate_assets_with_theme(
+      case fetch_and_associate_assets_with_theme(
              theme,
              current_user,
              params,

--- a/lib/wraft_doc/template_assets.ex
+++ b/lib/wraft_doc/template_assets.ex
@@ -463,7 +463,7 @@ defmodule WraftDoc.TemplateAssets do
   defp prepare_theme(theme, current_user, downloaded_file, entries) do
     with asset_ids <- prepare_theme_assets(entries, downloaded_file, current_user),
          params <- prepare_theme_attrs(theme, asset_ids),
-         %Theme{} = theme <- Document.create_theme(current_user, params) do
+         {:ok, %Theme{} = theme} <- Document.create_theme(current_user, params) do
       {:ok, theme}
     end
   end

--- a/lib/wraft_doc_web/controllers/theme_controller.ex
+++ b/lib/wraft_doc_web/controllers/theme_controller.ex
@@ -203,7 +203,7 @@ defmodule WraftDocWeb.Api.V1.ThemeController do
   def create(conn, params) do
     current_user = conn.assigns[:current_user]
 
-    with %Theme{} = theme <- Document.create_theme(current_user, params) do
+    with {:ok, %Theme{} = theme} <- Document.create_theme(current_user, params) do
       Typesense.create_document(theme)
       render(conn, "create.json", theme: theme)
     end
@@ -305,7 +305,7 @@ defmodule WraftDocWeb.Api.V1.ThemeController do
     current_user = conn.assigns[:current_user]
 
     with %Theme{} = theme <- Document.get_theme(theme_uuid, current_user),
-         %Theme{} = theme <- Document.update_theme(theme, current_user, params) do
+         {:ok, %Theme{} = theme} <- Document.update_theme(theme, current_user, params) do
       Typesense.update_document(theme)
       render(conn, "create.json", theme: theme)
     end

--- a/test/wraft_doc/document/document_test.exs
+++ b/test/wraft_doc/document/document_test.exs
@@ -3100,7 +3100,7 @@ defmodule WraftDoc.DocumentTest do
         |> Repo.all()
         |> length()
 
-      theme =
+      {:ok, theme} =
         Document.create_theme(
           user,
           Map.merge(@valid_theme_attrs, %{"assets" => "#{asset1.id},#{asset2.id}"})
@@ -3324,7 +3324,7 @@ defmodule WraftDoc.DocumentTest do
         |> Repo.all()
         |> length()
 
-      theme =
+      {:ok, theme} =
         Document.update_theme(
           theme,
           user,


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [x] Feature addition
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please specify)

## Description

Add validation to check regular font file is exist. If not we cant create or update theme

## Related Issue
WRA-383 https://linear.app/functionary/issue/WRA-383/ensure-theme-includes-required-font-files-to-prevent-build-failures

## How Has This Been Tested?

Tested create and update theme locally with front end

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.

