### PR TITLE
fix: add version preload for build in pipeline pathway

### DIFF
--- a/lib/wraft_doc/documents/documents.ex
+++ b/lib/wraft_doc/documents/documents.ex
@@ -110,9 +110,9 @@ defmodule WraftDoc.Documents do
     |> case do
       {:ok, %{instance: content}} ->
         versions_preload_query =
-          from(v in Version,
-            where: v.content_id == ^content.id and v.type == :build,
-            order_by: [desc: v.inserted_at],
+          from(version in Version,
+            where: version.content_id == ^content.id and version.type == :build,
+            order_by: [desc: version.inserted_at],
             preload: [:author]
           )
 
@@ -669,8 +669,8 @@ defmodule WraftDoc.Documents do
   def show_instance(instance_id, user) do
     # Preload the build versions of the instance
     versions_preload_query =
-      from(v in Version,
-        where: v.content_id == ^instance_id and v.type == :build,
+      from(version in Version,
+        where: version.content_id == ^instance_id and version.type == :build,
         preload: [:author]
       )
 

--- a/mix.exs
+++ b/mix.exs
@@ -157,10 +157,7 @@ defmodule WraftDoc.Mixfile do
 
       # live collaboration
       {:rustler, ">= 0.34.0"},
-      {:y_ex, "~> 0.6.5"},
-
-      # yaml parser
-      {:yaml_elixir, "~> 2.11.0"}
+      {:y_ex, "~> 0.6.5"}
     ]
   end
 


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [ ] Feature addition
- [x] Bug fix
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please specify)

## Description

Document generated was not loading if it is generated via pipeline trigger or form entry

## Motivation and Context

It would require user to regenerate after the pipeline trigger to get the document.

## How Has This Been Tested?

Tested via UI by triggering the pipeline and then checking out the generated document for the pdf.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.
