### PR TITLE
feat: add updation for email and password via admin panel

### DIFF
--- a/lib/wraft_doc/internal_users/internal_user.ex
+++ b/lib/wraft_doc/internal_users/internal_user.ex
@@ -23,9 +23,12 @@ defmodule WraftDoc.InternalUsers.InternalUser do
     |> generate_encrypted_password
   end
 
-  def deactivate_changeset(internal_user, attrs) do
+  def update_changeset(internal_user, attrs \\ %{}) do
     internal_user
-    |> cast(attrs, [:is_deactivated])
-    |> validate_required([:is_deactivated])
+    |> cast(attrs, [:email, :password, :is_deactivated])
+    |> validate_required([:email, :password, :is_deactivated])
+    |> validate_format(:email, ~r/^[^\s]+@[^\s]+\.[^\s]+$/, message: "has invalid format")
+    |> unique_constraint(:email, message: "Email already taken.! Try another email.")
+    |> generate_encrypted_password
   end
 end

--- a/lib/wraft_doc_web/admin/internal_user_admin.ex
+++ b/lib/wraft_doc_web/admin/internal_user_admin.ex
@@ -25,6 +25,6 @@ defmodule WraftDocWeb.InternalUserAdmin do
   end
 
   def update_changeset(%InternalUser{} = internal_user, attrs) do
-    InternalUser.deactivate_changeset(internal_user, attrs)
+    InternalUser.update_changeset(internal_user, attrs)
   end
 end


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [x] Feature addition

## Description

Internal users can have their email or password updated.

## Motivation and Context

* Currently we are creating a default wraftadmin when migrations are run initially.
* It is wiser to change the default user name and password because of potential security issue.

## How Has This Been Tested?

Tested via UI logging into the admin panel.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.
