### PR TITLE
feat: move document build as background job and additionally an api t…

### DIFF
--- a/lib/wraft_doc/documents/build_history.ex
+++ b/lib/wraft_doc/documents/build_history.ex
@@ -6,8 +6,11 @@ defmodule WraftDoc.Documents.Instance.History do
 
   alias __MODULE__
 
+  @statuses [:enqueued, :executing, :success, :failed]
+  @fields ~w(status exit_code start_time end_time delay)a
+
   schema "build_history" do
-    field(:status, :string)
+    field(:status, Ecto.Enum, values: @statuses)
     field(:exit_code, :integer)
     field(:start_time, :naive_datetime)
     field(:end_time, :naive_datetime)
@@ -19,7 +22,29 @@ defmodule WraftDoc.Documents.Instance.History do
 
   def changeset(%History{} = history, attrs \\ %{}) do
     history
-    |> cast(attrs, [:status, :exit_code, :start_time, :end_time, :delay])
-    |> validate_required([:status, :exit_code, :start_time, :end_time, :delay])
+    |> cast(attrs, @fields)
+    |> validate_required(@fields)
+  end
+
+  def status_update_changeset(%History{} = history, attrs \\ %{}) do
+    history
+    |> cast(attrs, [:status])
+    |> validate_required([:status])
+  end
+
+  def final_update_changeset(%History{} = history, attrs \\ %{}) do
+    history
+    |> cast(attrs, @fields -- [:delay])
+    |> validate_required(@fields -- [:delay])
+    |> calculate_delay()
+  end
+
+  defp calculate_delay(
+         %Ecto.Changeset{valid?: true, changes: %{end_time: end_time, start_time: start_time}} =
+           changeset
+       ) do
+    end_time
+    |> Timex.diff(start_time, :millisecond)
+    |> then(&put_change(changeset, :delay, &1))
   end
 end

--- a/lib/wraft_doc/documents/documents.ex
+++ b/lib/wraft_doc/documents/documents.ex
@@ -34,6 +34,7 @@ defmodule WraftDoc.Documents do
   alias WraftDoc.Utils.CSVHelper
   alias WraftDoc.Utils.ProsemirrorToMarkdown
   alias WraftDoc.Workers.BulkWorker
+  alias WraftDoc.Workers.DocumentWorker
   alias WraftDoc.Workers.EmailWorker
   alias WraftDocWeb.Mailer
   alias WraftDocWeb.Mailer.Email
@@ -698,22 +699,13 @@ defmodule WraftDoc.Documents do
   @spec get_built_document(Instance.t()) :: Instance.t() | nil
   def get_built_document(
         %{
-          id: id,
           instance_id: instance_id,
           content_type: %ContentType{organisation_id: org_id},
           versions: build_versions
         } = instance
       ) do
-    query =
-      from(h in History,
-        where: h.exit_code == 0,
-        where: h.content_id == ^id,
-        order_by: [desc: h.inserted_at],
-        limit: 1
-      )
-
-    query
-    |> Repo.one()
+    instance
+    |> get_build_history()
     |> case do
       nil ->
         instance
@@ -728,6 +720,18 @@ defmodule WraftDoc.Documents do
 
         Map.put(instance, :build, doc_url)
     end
+  end
+
+  @doc """
+  Get the build document of the given instance.
+  """
+  @spec get_build_history(Instance.t()) :: History.t() | nil
+  def get_build_history(%Instance{id: id}) do
+    History
+    |> where([h], h.exit_code == 0 and h.content_id == ^id)
+    |> order_by([h], desc: h.inserted_at)
+    |> limit(1)
+    |> Repo.one()
   end
 
   @doc """
@@ -918,6 +922,16 @@ defmodule WraftDoc.Documents do
   end
 
   def get_engine(_), do: {:error, :invalid_id, Engine}
+
+  @doc """
+  Creates a document worker job
+  """
+  @spec create_document_worker_job(map(), binary()) :: {:ok, Oban.Job.t()} | {:error, term()}
+  def create_document_worker_job(args, tag) do
+    args
+    |> DocumentWorker.new(tags: [tag])
+    |> Oban.insert()
+  end
 
   @doc """
   Build a PDF document.
@@ -1147,6 +1161,33 @@ defmodule WraftDoc.Documents do
   end
 
   defp move_old_builds(_, _, false), do: nil
+
+  @doc """
+    Create build history
+  """
+  @spec create_initial_build_history(User.t(), Instance.t()) :: History.t() | nil
+  def create_initial_build_history(%User{} = current_user, %Instance{} = instance) do
+    current_user
+    |> build_assoc(:build_histories, content: instance)
+    |> History.status_update_changeset(%{status: "enqueued"})
+    |> Repo.insert!()
+  end
+
+  @doc """
+  Update build history
+  """
+  @spec update_build_history(History.t(), map()) :: History.t() | nil
+  def update_build_history(%History{} = build_history, %{status: "executing"} = params) do
+    build_history
+    |> History.status_update_changeset(params)
+    |> Repo.update!()
+  end
+
+  def update_build_history(%History{} = build_history, params) do
+    build_history
+    |> History.final_update_changeset(params)
+    |> Repo.update!()
+  end
 
   @doc """
   Insert the build history of the given instance.

--- a/lib/wraft_doc/workers/document_worker.ex
+++ b/lib/wraft_doc/workers/document_worker.ex
@@ -1,0 +1,53 @@
+defmodule WraftDoc.Workers.DocumentWorker do
+  @moduledoc """
+  Oban worker for building of docs.
+  """
+  use Oban.Worker, queue: :events, max_attempts: 1
+
+  alias WraftDoc.Documents
+  require Logger
+
+  @impl Oban.Worker
+  def perform(%Job{
+        args: %{
+          "user" => user,
+          "build_history" => build_history,
+          "instance" => instance,
+          "layout" => layout,
+          "params" => params
+        },
+        tags: ["document_job"]
+      }) do
+    Logger.info("Job starting for running the document build...")
+
+    start_time = Timex.now()
+
+    Documents.update_build_history(build_history, %{status: "executing"})
+
+    case Documents.build_doc(instance, layout) do
+      {_, 0} ->
+        Logger.info("Document build successful!")
+
+        Documents.update_build_history(build_history, %{
+          status: "success",
+          start_time: start_time,
+          end_time: Timex.now(),
+          exit_code: 0
+        })
+
+        Documents.create_version(user, instance, params, :build)
+
+      {_, exit_code} ->
+        Logger.error("Document build failed with exit code #{exit_code}")
+
+        Documents.update_build_history(build_history, %{
+          status: "failed",
+          start_time: start_time,
+          end_time: Timex.now(),
+          exit_code: exit_code
+        })
+    end
+
+    Logger.info("Job end for running the document build.")
+  end
+end

--- a/lib/wraft_doc_web/controllers/instance_controller.ex
+++ b/lib/wraft_doc_web/controllers/instance_controller.ex
@@ -28,6 +28,7 @@ defmodule WraftDocWeb.Api.V1.InstanceController do
   alias WraftDoc.ContentTypes.ContentType
   alias WraftDoc.Documents
   alias WraftDoc.Documents.Instance
+  alias WraftDoc.Documents.Instance.History
   alias WraftDoc.Documents.Instance.Version
   alias WraftDoc.Enterprise
   alias WraftDoc.Enterprise.Flow.State
@@ -779,29 +780,28 @@ defmodule WraftDocWeb.Api.V1.InstanceController do
   end
 
   @spec build(Plug.Conn.t(), map) :: Plug.Conn.t()
-  def build(conn, %{"id" => instance_id} = params) do
+  def build(conn, %{"id" => document_id} = params) do
     current_user = conn.assigns[:current_user]
-    start_time = Timex.now()
 
-    case Documents.show_instance(instance_id, current_user) do
-      %Instance{content_type: %{layout: layout}} = instance ->
-        with %Layout{} = layout <- Assets.preload_asset(layout),
-             {_, exit_code} <- Documents.build_doc(instance, layout) do
-          end_time = Timex.now()
-
-          Task.start_link(fn ->
-            Documents.add_build_history(current_user, instance, %{
-              start_time: start_time,
-              end_time: end_time,
-              exit_code: exit_code
-            })
-          end)
-
-          handle_response(conn, exit_code, instance, params)
-        end
-
-      _ ->
-        {:error, :not_sufficient}
+    with %Instance{content_type: %{layout: layout}} = instance <-
+           Documents.show_instance(document_id, current_user),
+         %Layout{} = layout <- Assets.preload_asset(layout),
+         %History{} = build_history <-
+           Documents.create_initial_build_history(current_user, instance),
+         {:ok, %Oban.Job{}} <-
+           Documents.create_document_worker_job(
+             %{
+               "user" => current_user,
+               "instance" => instance,
+               "build_history" => build_history,
+               "layout" => layout,
+               "params" => params
+             },
+             "document_job"
+           ) do
+      conn
+      |> put_status(:accepted)
+      |> json(%{message: "Build started"})
     end
   rescue
     DownloadError ->
@@ -810,20 +810,37 @@ defmodule WraftDocWeb.Api.V1.InstanceController do
       |> json(%{error: "File not found"})
   end
 
-  defp handle_response(conn, exit_code, instance, params) do
-    case exit_code do
-      0 ->
-        Task.start_link(fn ->
-          Documents.create_version(conn.assigns.current_user, instance, params, :build)
-        end)
+  swagger_path :build_status do
+    get("/contents/{id}/build_status")
+    summary("Get build status")
+    description("API to get build status")
 
-        render(conn, "instance.json", instance: instance)
-
-      _ ->
-        conn
-        |> put_status(:unprocessable_entity)
-        |> render("build_fail.json", %{exit_code: exit_code})
+    parameters do
+      id(:path, :string, "instance id", required: true)
     end
+
+    response(200, "Ok", Schema.ref(:Content))
+    response(422, "Unprocessable Entity", Schema.ref(:Error))
+    response(401, "Unauthorized", Schema.ref(:Error))
+    response(404, "Not found", Schema.ref(:Error))
+  end
+
+  @spec build_status(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def build_status(conn, %{"id" => document_id}) do
+    current_user = conn.assigns[:current_user]
+
+    with %Instance{} = instance <- Documents.show_instance(document_id, current_user),
+         %History{status: "success"} <- Documents.get_build_history(instance) do
+      render(conn, "instance.json", instance: instance)
+    else
+      %History{status: status, exit_code: exit_code} ->
+        render(conn, "build_status.json", %{status: status, exit_code: exit_code})
+    end
+  rescue
+    DownloadError ->
+      conn
+      |> put_status(404)
+      |> json(%{error: "File not found"})
   end
 
   @doc """

--- a/lib/wraft_doc_web/router.ex
+++ b/lib/wraft_doc_web/router.ex
@@ -387,6 +387,8 @@ defmodule WraftDocWeb.Router do
 
       # build PDF from a content
       post("/contents/:id/build", InstanceController, :build)
+      # build status
+      get("/contents/:id/build_status", InstanceController, :build_status)
 
       # All data in an organisation
       get("/data_templates", DataTemplateController, :all_templates)

--- a/lib/wraft_doc_web/views/instance_view.ex
+++ b/lib/wraft_doc_web/views/instance_view.ex
@@ -131,9 +131,9 @@ defmodule WraftDocWeb.Api.V1.InstanceView do
     }
   end
 
-  def render("build_fail.json", %{exit_code: exit_code}) do
+  def render("build_status.json", %{status: status, exit_code: exit_code}) do
     %{
-      info: "Build failed",
+      status: status,
       exit_code: exit_code
     }
   end


### PR DESCRIPTION
…o check build status

# Pull Request Description

## Changes Made

- [x] Performance improvement
- [x] Refactoring

## Description

* Move document build generation as a background job.
* Create an additional API to check the build status

## Motivation and Context

Moving document build generation as a background job as it is a long running process and by doing so would enhance the user experience. 

## How Has This Been Tested?

Tested via UI

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.

