### PR TITLE
fix: duplicate fields in frame mapping

### DIFF
--- a/lib/wraft_doc/frames/frames.ex
+++ b/lib/wraft_doc/frames/frames.ex
@@ -273,7 +273,7 @@ defmodule WraftDoc.Frames do
     content_type_field_names =
       Enum.map(content_type_fields, &format_name(&1.name))
 
-    mapping_source_names = Enum.map(mappings, &format_name(&1["source"]))
+    mapping_source_names = mappings |> Enum.map(&format_name(&1["source"])) |> Enum.uniq()
     mapping_destination_names = Enum.map(mappings, & &1["destination"])
 
     missing_content_type_fields = mapping_source_names -- content_type_field_names


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [x] Bug fix

## Description

If use variant fields multiple time in mapping an error is returned fixed that

## How Has This Been Tested?

Tested locally with UI, tried to create/ update variant and mapping and build document each cases.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.
