### PR TITLE
fix:  pdf signer jar file path issue

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -153,6 +153,7 @@ config :wraft_doc,
   theme_folder: "priv/wraft_files/Roboto",
   layout_file: "priv/wraft_files/letterhead.pdf",
   default_template_files: "priv/wraft_files/templates",
+  signature_jar_file: "priv/pdf-signer.jar",
   sender_email: "no-reply@#{System.get_env("WRAFT_HOSTNAME")}",
   frontend_url: "#{System.get_env("FRONTEND_URL")}",
   backend_url: "#{System.get_env("BACKEND_URL")}"

--- a/lib/wraft_doc/client/minio.ex
+++ b/lib/wraft_doc/client/minio.ex
@@ -9,6 +9,10 @@ defmodule WraftDoc.Client.Minio do
     defexception message: "MinIO download error. File not found."
   end
 
+  defmodule UploadError do
+    defexception message: "MinIO upload error. File not found."
+  end
+
   alias ExAws.Config
   alias ExAws.S3
   alias WraftDoc.Client.Minio.DownloadError
@@ -26,11 +30,15 @@ defmodule WraftDoc.Client.Minio do
   """
   @spec upload_file(String.t()) :: ex_aws_response()
   def upload_file(file_path) do
-    file_path
-    |> S3.Upload.stream_file()
-    |> S3.upload(bucket(), file_path)
-    |> @ex_aws_module.request()
-    |> handle_upload_response()
+    if File.exists?(file_path) do
+      file_path
+      |> S3.Upload.stream_file()
+      |> S3.upload(bucket(), file_path)
+      |> @ex_aws_module.request()
+      |> handle_upload_response()
+    else
+      raise UploadError
+    end
   end
 
   defp handle_upload_response({:ok, result}), do: {:ok, result}

--- a/lib/wraft_doc/documents/signatures.ex
+++ b/lib/wraft_doc/documents/signatures.ex
@@ -6,16 +6,8 @@ defmodule WraftDoc.Documents.Signatures do
   import Ecto.Query
   require Logger
 
-  # Path to the visual signer JAR file
-  @visual_signer_jar Application.compile_env(
-                       :wraft_doc,
-                       :visual_signer_jar,
-                       Path.join(
-                         :code.priv_dir(:wraft_doc),
-                         "pdf-signer.jar"
-                       )
-                     )
-
+  # Path to the pdf signer JAR file
+  @visual_signer_jar Application.compile_env!(:wraft_doc, [:signature_jar_file])
   # Digital signature keystore configuration
   @keystore_file System.get_env("SIGNING_LOCAL_FILE_PATH") ||
                    Path.join(:code.priv_dir(:wraft_doc), "keystore/doc_signer.p12")
@@ -102,6 +94,8 @@ defmodule WraftDoc.Documents.Signatures do
       "--location",
       @signature_location
     ]
+
+    Logger.info("Applying visual signature with args: #{inspect(args)}")
 
     case System.cmd("java", args, stderr_to_stdout: true) do
       {output, 0} ->

--- a/lib/wraft_doc/documents/signatures.ex
+++ b/lib/wraft_doc/documents/signatures.ex
@@ -103,8 +103,6 @@ defmodule WraftDoc.Documents.Signatures do
       @signature_location
     ]
 
-    Logger.info("Executing visual signer with args: #{inspect(args)}")
-
     case System.cmd("java", args, stderr_to_stdout: true) do
       {output, 0} ->
         Logger.info("Visual signature applied successfully: #{output}")

--- a/lib/wraft_doc_web/controllers/signature_controller.ex
+++ b/lib/wraft_doc_web/controllers/signature_controller.ex
@@ -16,6 +16,7 @@ defmodule WraftDocWeb.Api.V1.SignatureController do
   alias WraftDoc.AuthTokens.AuthToken
   alias WraftDoc.Client.Minio
   alias WraftDoc.Client.Minio.DownloadError
+  alias WraftDoc.Client.Minio.UploadError
   alias WraftDoc.CounterParties
   alias WraftDoc.CounterParties.CounterParty
   alias WraftDoc.Documents
@@ -528,5 +529,10 @@ defmodule WraftDocWeb.Api.V1.SignatureController do
            CounterParties.counter_party_sign(counter_party, params, signed_pdf_path) do
       render(conn, "signed_pdf.json", url: Minio.generate_url(signed_pdf_path))
     end
+  rescue
+    UploadError ->
+      conn
+      |> put_status(404)
+      |> json(%{error: "File not found"})
   end
 end


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [x] Bug fix

## Description

Path issue with taking the correct path of the pdf-signer in production

## Motivation and Context

Why is this change required? What problem does it solve?

It solves the path issue with pdf signer jar file.

## How Has This Been Tested?

Has been checked in production logs as well as reproduced locally.

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings.
- [x] I have checked my code and corrected any misspellings.
