### PR TITLE
feat: add document stats by variants

### DIFF
--- a/lib/wraft_doc/schedulers/refresh_dashboard_stats.ex
+++ b/lib/wraft_doc/schedulers/refresh_dashboard_stats.ex
@@ -1,11 +1,11 @@
 defmodule WraftDoc.Schedulers.RefreshDashboardStats do
   @moduledoc """
-  Refreshes the dashboard stats
+  Refreshes the dashboard stats and documents by content type stats materialized views
   """
   use GenServer
 
-  # Refresh every hour
-  @refresh_interval :timer.minutes(30)
+  # Refresh every 15 minutes
+  @refresh_interval :timer.minutes(15)
 
   def start_link(_) do
     GenServer.start_link(__MODULE__, %{})
@@ -28,5 +28,6 @@ defmodule WraftDoc.Schedulers.RefreshDashboardStats do
 
   defp refresh_materialized_view do
     WraftDoc.Repo.query!("REFRESH MATERIALIZED VIEW dashboard_stats")
+    WraftDoc.Repo.query!("REFRESH MATERIALIZED VIEW documents_by_content_type_stats")
   end
 end

--- a/lib/wraft_doc_web/controllers/dashboard_controller.ex
+++ b/lib/wraft_doc_web/controllers/dashboard_controller.ex
@@ -26,6 +26,59 @@ defmodule WraftDocWeb.Api.V1.DashboardController do
             today_documents: 10,
             pending_approvals: 5
           })
+        end,
+      DocumentsByContentTypeResponse:
+        swagger_schema do
+          title("Documents by content type")
+          description("Document counts grouped by content type")
+
+          properties do
+            data(:array, "Array of document counts by content type",
+              items: Schema.ref(:DocumentCountByType)
+            )
+          end
+
+          example(%{
+            data: [
+              %{
+                id: "123e4567-e89b-12d3-a456-426614174000",
+                name: "Contract",
+                color: "#FF5733",
+                count: 25
+              },
+              %{
+                id: "123e4567-e89b-12d3-a456-426614174001",
+                name: "Invoice",
+                color: "#33FF57",
+                count: 15
+              },
+              %{
+                id: "123e4567-e89b-12d3-a456-426614174002",
+                name: "Report",
+                color: "#3357FF",
+                count: 10
+              }
+            ]
+          })
+        end,
+      DocumentCountByType:
+        swagger_schema do
+          title("Document count by type")
+          description("Document count for a specific content type")
+
+          properties do
+            id(:string, "Content type ID", required: true)
+            name(:string, "Content type name", required: true)
+            color(:string, "Content type color (hex code)", required: false)
+            count(:integer, "Number of documents", required: true)
+          end
+
+          example(%{
+            id: "123e4567-e89b-12d3-a456-426614174000",
+            name: "Contract",
+            color: "#FF5733",
+            count: 25
+          })
         end
     }
   end
@@ -52,6 +105,29 @@ defmodule WraftDocWeb.Api.V1.DashboardController do
 
     with stats <- Documents.get_dashboard_stats(current_user) do
       render(conn, "dashboard_stats.json", stats: stats)
+    end
+  end
+
+  @doc """
+  Get documents by content type
+  """
+  swagger_path :documents_by_content_type do
+    get("/documents/by_content_type")
+    summary("Get documents by content type")
+
+    description("Get document counts grouped by content type for the current organization")
+
+    response(200, "OK", Schema.ref(:DocumentsByContentTypeResponse))
+    response(422, "Unprocessable Entity", Schema.ref(:Error))
+    response(401, "Unauthorized", Schema.ref(:Error))
+  end
+
+  @spec documents_by_content_type(Plug.Conn.t(), map) :: Plug.Conn.t()
+  def documents_by_content_type(conn, _params) do
+    current_user = conn.assigns.current_user
+
+    with data <- Documents.get_documents_by_content_type(current_user) do
+      render(conn, "documents_by_content_type.json", data: data)
     end
   end
 end

--- a/lib/wraft_doc_web/router.ex
+++ b/lib/wraft_doc_web/router.ex
@@ -190,6 +190,8 @@ defmodule WraftDocWeb.Router do
       put("/user/password", UserController, :update_password)
       # Dashboard Stats
       get("/dashboard_stats", DashboardController, :dashboard_stats)
+      # Documents by content type
+      get("/documents/by_content_type", DashboardController, :documents_by_content_type)
       # Layout
       resources("/layouts", LayoutController, only: [:create, :index, :show, :update, :delete])
       # Delete layout asset

--- a/lib/wraft_doc_web/views/dashboard_view.ex
+++ b/lib/wraft_doc_web/views/dashboard_view.ex
@@ -8,4 +8,8 @@ defmodule WraftDocWeb.Api.V1.DashboardView do
       pending_approvals: stats.pending_approvals
     }
   end
+
+  def render("documents_by_content_type.json", %{data: data}) do
+    data
+  end
 end

--- a/priv/repo/migrations/20250622125436_create_documents_by_content_type_stats_view.exs
+++ b/priv/repo/migrations/20250622125436_create_documents_by_content_type_stats_view.exs
@@ -1,0 +1,27 @@
+defmodule WraftDoc.Repo.Migrations.CreateDocumentsByContentTypeStatsView do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    CREATE MATERIALIZED VIEW documents_by_content_type_stats AS
+    SELECT
+      ct.organisation_id,
+      ct.id::text AS id,
+      ct.name AS name,
+      ct.color AS color,
+      COUNT(i.id) AS count
+    FROM
+      content_type ct
+    LEFT JOIN
+      content i ON i.content_type_id = ct.id
+    GROUP BY
+      ct.organisation_id, ct.id, ct.name, ct.color
+    ORDER BY
+      ct.name
+    """)
+  end
+
+  def down do
+    execute("DROP MATERIALIZED VIEW IF EXISTS documents_by_content_type_stats")
+  end
+end


### PR DESCRIPTION
# Pull Request Description

## Changes Made

- [x] Feature addition  
- [ ] Bug fix  
- [ ] Performance improvement  
- [ ] Refactoring  
- [ ] Documentation update  
- [ ] Other (please specify)

## Description

This PR introduces content-type-based statistics for documents within the current organization. It includes:

- A new API endpoint to fetch document counts grouped by content type  
- A materialized view for efficient retrieval of content-type statistics  
- Updates to the dashboard stats refresh logic to incorporate the new data source  
- Enhancements to the dashboard controller and view to render the updated response structure

## Motivation and Context

This feature enables users to better understand the distribution of documents by content type, supporting insights and reporting capabilities on the dashboard.

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project  
- [x] I have updated the documentation accordingly  
- [x] I have added tests to cover my changes  
- [x] All new and existing tests passed  
- [x] My changes generate no new warnings  
- [x] I have checked my code and corrected any misspellings
